### PR TITLE
修复在用户未初始化时启动过程中发生空指针解引用崩溃

### DIFF
--- a/kernel/model/cloud_service.go
+++ b/kernel/model/cloud_service.go
@@ -233,7 +233,7 @@ func refreshSubscriptionExpirationRemind() {
 
 	defer logging.Recover()
 
-	if IsSubscriber() && -1 != Conf.GetUser().UserSiYuanProExpireTime {
+	if IsSubscriber() && nil != Conf.GetUser() && -1 != Conf.GetUser().UserSiYuanProExpireTime {
 		expired := int64(Conf.GetUser().UserSiYuanProExpireTime)
 		now := time.Now().UnixMilli()
 		if now >= expired { // 已经过期


### PR DESCRIPTION
在部署web系统时，发现在用户未初始化时启动过程中发生空指针解引用崩溃的bug，没有看到有dev分支，于是提交到了唯一的分支。